### PR TITLE
Improve access to debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ db_init:
 db_init_force:
 	./cesium_launcher --db-init --force
 
-run_debug: dev_dependencies dependencies
 
 $(bundle): webpack.config.js
 	$(webpack)
@@ -41,8 +40,15 @@ paths:
 log: paths
 	./tools/watch_logs.py
 
-run: paths $(bundle) dependencies
-	$(SUPERVISORD) -c supervisord.conf
+run: paths dependencies
+	$(SUPERVISORD) -c conf/supervisord.conf
+
+debug:
+	$(SUPERVISORD) -c conf/supervisord_debug.conf
+
+# Attach to terminal of running webserver; useful to, e.g., use pdb
+attach:
+	supervisorctl -c conf/supervisord_common.conf fg flask
 
 clean:
 	rm $(bundle)

--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ See the above section to run the app from here.
 ## Dev tips
 
 - Run `make log` to watch log output
+- Run `make debug` to start webserver in debug mode
+- Run `make attach` to attach to output of webserver; you can then set pdb
+  traces for interactive access:
+
+    import pdb; pdb.set_trace()
 

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,0 +1,12 @@
+[include]
+files = supervisord_common.conf
+
+[program:flask]
+command=waitress-serve --port=65000 --asyncore-use-poll cesium_app.flask_server:app
+# Use the following to serve on unix socket instead:
+#  command=waitress-serve --unix-socket=run/flask_app.sock --asyncore-use-poll --unix-socket-perms=666 cesium_app.flask_server:app
+# Remember to also reconfigure nginx.conf
+
+environment=PYTHONUNBUFFERED=1
+stdout_logfile=log/waitress.log
+redirect_stderr=true

--- a/conf/supervisord_common.conf
+++ b/conf/supervisord_common.conf
@@ -13,19 +13,12 @@ file=/tmp/supervisor.sock
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
-
 ## For development only: uncomment in production
 [program:webpack]
 command=./node_modules/.bin/webpack -w
 stdout_logfile=log/webpack.log
 redirect_stderr=true
 ##
-
-[program:waitress]
-command=waitress-serve --unix-socket=run/flask_app.sock --asyncore-use-poll --unix-socket-perms=666 cesium_app.flask_server:app
-environment=PYTHONUNBUFFERED=1
-stdout_logfile=log/waitress.log
-redirect_stderr=true
 
 [program:nginx]
 command=nginx -c nginx.conf -p . -g "daemon off;"

--- a/conf/supervisord_debug.conf
+++ b/conf/supervisord_debug.conf
@@ -1,0 +1,8 @@
+[include]
+files = supervisord_common.conf
+
+[program:flask]
+command=flask run --port=65000
+environment=PYTHONUNBUFFERED=1,FLASK_APP=cesium_app/flask_server.py,FLASK_DEBUG=1
+stdout_logfile=log/waitress.log
+redirect_stderr=true

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,14 +5,18 @@ http {
   sendfile on;
 
   upstream websocket_server {
-    server localhost:4567;
+    server localhost:64000;
   }
 
   server {
     listen 5000;
 
     location / {
-      proxy_pass http://unix:run/flask_app.sock:/;
+      # You can also run the webserver through a socket:
+      #   proxy_pass http://unix:run/flask_app.sock:/;
+      # Also see supervisor.conf
+
+      proxy_pass http://127.0.0.1:65000;
 
       proxy_set_header        Host $http_host;
       proxy_set_header        X-Real-IP $remote_addr;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/cesium-ml/cesium/archive/master.zip # >=0.4.0 once released
-flask
+flask>=0.11
 peewee
 psycopg2
 requests

--- a/services/websocket_server.py
+++ b/services/websocket_server.py
@@ -78,7 +78,7 @@ class WebSocket(websocket.WebSocketHandler):
 
 
 if __name__ == "__main__":
-    PORT = 4567
+    PORT = 64000
     LOCAL_OUTPUT = 'ipc:///tmp/message_flow_out'
 
     import zmq


### PR DESCRIPTION
- Flask can now be run in debug mode, using `make debug`
- You can attach to the running flask server, using `make attach`.  This
  allows you to use pdb set_trace in the code.
- The webserver can still be run in production mode, using `make`
- The webserver no longer uses unix sockets to communicate on, but HTTP
  instead.  This is left as a potential deployment optimization.
