### PR TITLE
Fix prediction results table logic error

### DIFF
--- a/public/scripts/Models.js
+++ b/public/scripts/Models.js
@@ -163,9 +163,13 @@ export var ModelTable = (props) => {
   );
 }
 
-let mtMapStateToProps = (state) => {
+let mtMapStateToProps = (state, ownProps) => {
   return {
-    models: state.models
+    models: state.models.filter(
+      model => {
+        return (model.project == ownProps.selectedProject.id);
+      }
+    )
   }
 }
 

--- a/public/scripts/Predictions.js
+++ b/public/scripts/Predictions.js
@@ -120,7 +120,8 @@ let PredictionResults = (props) => {
   let results = props.prediction.results;
 
   let firstResult = results ? results[Object.keys(results)[0]] : null;
-  let classes = Object.keys(firstResult.prediction)
+  let classes = (firstResult && firstResult.prediction) ?
+                Object.keys(firstResult.prediction) : null;
 
   let modelHasProba = contains(['RandomForestClassifier',
                                 'LinearSGDClassifier'],

--- a/public/scripts/Predictions.js
+++ b/public/scripts/Predictions.js
@@ -132,14 +132,14 @@ let PredictionResults = (props) => {
                                 modelType)
   let modelHasClass = contains(['RidgeClassifierCV'], modelType)
 
-  let hasTarget = (p) => (p.target != null)
+  let hasTrueTargetLabel = (p) => (p.target != null)
 
   return (
     <table className='table'>
       <thead>
         <tr>
           <th>Time Series</th>
-          {hasTarget(firstResult) && <th>True Class/Target</th>}
+          {hasTrueTargetLabel(firstResult) && <th>True Class/Target</th>}
 
           {modelHasProba &&
            classes.map((classLabel, idx) => ([
@@ -162,7 +162,7 @@ let PredictionResults = (props) => {
 
             <td>{fname}</td>
 
-            {[hasTarget(result) &&
+            {[hasTrueTargetLabel(result) &&
               <td key="pt">{result.target}</td>,
 
               modelHasProba &&

--- a/public/scripts/Predictions.js
+++ b/public/scripts/Predictions.js
@@ -162,7 +162,7 @@ let PredictionResults = (props) => {
 
             <td>{fname}</td>
 
-            {hasTarget(result) && [
+            {[hasTarget(result) &&
               <td key="pt">{result.target}</td>,
 
               modelHasProba &&


### PR DESCRIPTION
Still to do:
- Make sure objects/arrays are not null before attempting to map/index etc.
