### PR TITLE
Do not track web access log

### DIFF
--- a/tools/watch_logs.py
+++ b/tools/watch_logs.py
@@ -99,7 +99,6 @@ with nostdout():
 watched.append(cfg['paths']['err_log_path'])
 watched.append('log/error.log')
 watched.append('log/nginx-error.log')
-watched.append('log/nginx-access.log')
 
 
 def tail_f(filename, interval=1.0):


### PR DESCRIPTION
There are too many entries in this log file to make it useful.  The file still
exists, and can be monitored should that prove useful for debugging.