### PR TITLE
Silently execute dependency monitoring tools (unless they fail)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,18 @@ bundle = ./public/build/bundle.js
 webpack = ./node_modules/.bin/webpack
 
 
-dev_dependencies:
-	@./tools/install_deps.py requirements.dev.txt
-
 dependencies:
-	@./tools/install_deps.py requirements.txt
-	@./tools/check_js_deps.sh
+	@./tools/silent_monitor.py ./tools/install_deps.py requirements.txt
+	@./tools/silent_monitor.py ./tools/check_js_deps.sh
 
 db_init:
-	./tools/db_create.sh
+	@./tools/silent_monitor.py ./tools/db_create.sh
 
 db_drop:
-	PYTHONPATH=. ./tools/db_drop.py
+	@PYTHONPATH=. ./tools/silent_monitor.py ./tools/db_drop.py
 
 db_test_data:
-	PYTHONPATH=. python ./cesium_app/models.py
+	@PYTHONPATH=. python ./cesium_app/models.py
 
 $(bundle): webpack.config.js package.json
 	$(webpack)
@@ -32,9 +29,9 @@ bundle-watch:
 	$(webpack) -w
 
 paths:
-	mkdir -p log run tmp
-	mkdir -p log/sv_child
-	mkdir -p ~/.local/cesium/logs
+	@mkdir -p log run tmp
+	@mkdir -p log/sv_child
+	@mkdir -p ~/.local/cesium/logs
 
 log: paths
 	./tools/watch_logs.py
@@ -68,5 +65,5 @@ docker-images:
 
 # Call this target to see which Javascript dependencies are not up to date
 check-js-updates:
-	@./tools/check_js_updates.sh
+	./tools/check_js_updates.sh
 

--- a/tools/check_js_deps.sh
+++ b/tools/check_js_deps.sh
@@ -5,15 +5,16 @@ set -e
 CHECKER='./node_modules/.bin/check-dependencies'
 
 if [[ ! -x ${CHECKER} ]]; then
-    npm install check-dependencies > /dev/null 2>&1
+    npm install check-dependencies
 fi
 
 # We suppress output for the next command because, annoyingly, it reports
 # that a dependency is unsatisfied even if the --install flag is specified,
 # and that package has been successfully installed
-${CHECKER} --install > /dev/null 2>&1
+${CHECKER} --install
 
 # Print report, if any unsatisfied dependencies remain
 if ${CHECKER}; then
     echo "✓ All Javascript dependencies satisfied."
 fi
+

--- a/tools/install_deps.py
+++ b/tools/install_deps.py
@@ -25,7 +25,7 @@ with open(req_file) as f:
         if '-e' in dep:
             dep = dep.split('#egg=')[-1]   # use the egg name
         else:
-            dep = re.split('\W+', dep)[0]  # discard version info
+            dep = re.split('[^\w\-]+', dep)[0]  # discard version info
 
         try:
             __import__(pkg_import.get(dep, dep))

--- a/tools/silent_monitor.py
+++ b/tools/silent_monitor.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+import shlex
+
+if len(sys.argv) < 2:
+    print('Usage: silent_monitor.py <cmd to execute>')
+    sys.exit()
+
+cmd = ' '.join(sys.argv[1:])
+
+tag = 'Silently executing: {}'.format(cmd)
+print('[·] {}'.format(tag), end='')
+sys.stdout.flush()
+
+p = subprocess.Popen(shlex.split(cmd),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+err = p.wait()
+stdout, stderr = p.stderr.read().strip(), p.stdout.read().strip()
+
+if err == 0:
+    print('\r[✓] {}'.format(tag))
+else:
+    print('\r[✗] {}'.format(tag))
+    print('\n! Failure (exit code {}).'.format(err, cmd))
+
+    if stdout:
+        print('--- stdout ---')
+        print(stdout.decode('utf-8'))
+
+    if stderr:
+        print('--- stderr ---')
+        print(stderr.decode('utf-8'))
+
+    if stdout or stderr:
+        print('--- end ---')
+
+    sys.exit(err)
+


### PR DESCRIPTION
Before, we'd dump the output to /dev/null.  Unfortunately, when things go
wrong the user gets no feedback.  Now, we monitor the process, and if it fails
dumps stdout and stderr.

Also a minor fix to the Python dependency monitor: a regexp that can handle
packages with '-' in the name.