### PR TITLE
On dependent builds, only install trigerring repo when it is cesium-ml/cesium

### DIFF
--- a/.travis/travis_install.sh
+++ b/.travis/travis_install.sh
@@ -20,7 +20,7 @@ node --version
 make dependencies
 make check-js-updates
 
-if [[ -n ${TRIGGERED_FROM_REPO} ]]; then
+if [[ ${TRIGGERED_FROM_REPO} == "cesium-ml/cesium" ]]; then
     mkdir cesium-clone
     cd cesium-clone
     git init


### PR DESCRIPTION
Currently, the build checks the triggering repo and tries to install.
If the triggering repo is baselayer, that does not work (and should not
happen).